### PR TITLE
feat: “Información de hoy” + “Historial” y conexión desde AddInfo (modo demo)

### DIFF
--- a/contador_pasos/android/app/build.gradle.kts
+++ b/contador_pasos/android/app/build.gradle.kts
@@ -8,7 +8,8 @@ plugins {
 android {
     namespace = "com.example.contador_pasos"
     compileSdk = flutter.compileSdkVersion
-    ndkVersion = flutter.ndkVersion
+    //ndkVersion = flutter.ndkVersion
+    ndkVersion = "27.0.12077973"
 
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11

--- a/contador_pasos/lib/add_info_screen.dart
+++ b/contador_pasos/lib/add_info_screen.dart
@@ -1,8 +1,64 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
+import 'models/user_info.dart';
+import 'summary_screen.dart';
 
-class AddInfoScreen extends StatelessWidget {
+class AddInfoScreen extends StatefulWidget {
   const AddInfoScreen({super.key});
+
+  @override
+  State<AddInfoScreen> createState() => _AddInfoScreenState();
+}
+
+class _AddInfoScreenState extends State<AddInfoScreen> {
+  final _formKey = GlobalKey<FormState>();
+  final _pesoCtrl = TextEditingController();
+  final _alturaCtrl = TextEditingController();
+  final _edadCtrl = TextEditingController();
+  final _generoCtrl = TextEditingController();
+
+  @override
+  void dispose() {
+    _pesoCtrl.dispose();
+    _alturaCtrl.dispose();
+    _edadCtrl.dispose();
+    _generoCtrl.dispose();
+    super.dispose();
+  }
+
+  void _guardar() {
+    if (!(_formKey.currentState?.validate() ?? false)) return;
+
+    try {
+      final info = UserInfo(
+        pesoKg: double.parse(_pesoCtrl.text.replaceAll(',', '.')),
+        alturaCm: double.parse(_alturaCtrl.text.replaceAll(',', '.')),
+        edad: int.parse(_edadCtrl.text),
+        genero: _generoCtrl.text.isEmpty ? 'N/D' : _generoCtrl.text,
+      );
+
+      Navigator.of(context).pushReplacement(
+        MaterialPageRoute(builder: (_) => SummaryScreen(userInfo: info)),
+      );
+    } catch (e) {
+      _showError('Revisa los valores ingresados.');
+    }
+  }
+
+  void _showError(String msg) {
+    showDialog(
+      context: context,
+      builder: (ctx) => AlertDialog(
+        title: const Text('Datos inválidos'),
+        content: Text(msg),
+        actions: [
+          TextButton(onPressed: () => Navigator.of(ctx).pop(), child: const Text('OK')),
+        ],
+      ),
+    );
+  }
+
+  String? _req(String? v) => (v == null || v.trim().isEmpty) ? 'Requerido' : null;
 
   @override
   Widget build(BuildContext context) {
@@ -12,72 +68,80 @@ class AddInfoScreen extends StatelessWidget {
         backgroundColor: Colors.white,
         elevation: 0,
         leading: IconButton(
-          icon: Icon(Icons.arrow_back_ios, color: Colors.black),
+          icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
           onPressed: () => Navigator.of(context).pop(),
         ),
       ),
       body: SingleChildScrollView(
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 24.0),
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              const SizedBox(height: 20),
-              Text(
-                'Agrega\ntu información',
-                style: GoogleFonts.poppins(
-                  fontSize: 32,
-                  fontWeight: FontWeight.bold,
-                  color: Colors.black,
+          child: Form(
+            key: _formKey,
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                const SizedBox(height: 20),
+                Text(
+                  'Agrega\ntu información',
+                  style: GoogleFonts.poppins(
+                    fontSize: 32,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.black,
+                  ),
                 ),
-              ),
-              const SizedBox(height: 40),
-              TextField(
-                keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: 'Peso (kg)',
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                const SizedBox(height: 40),
+                TextFormField(
+                  controller: _pesoCtrl,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    labelText: 'Peso (kg)',
+                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                  validator: _req,
                 ),
-              ),
-              const SizedBox(height: 20),
-              TextField(
-                keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: 'Altura (cm)',
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _alturaCtrl,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    labelText: 'Altura (cm)',
+                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                  validator: _req,
                 ),
-              ),
-              const SizedBox(height: 20),
-              TextField(
-                keyboardType: TextInputType.number,
-                decoration: InputDecoration(
-                  labelText: 'Edad',
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _edadCtrl,
+                  keyboardType: TextInputType.number,
+                  decoration: InputDecoration(
+                    labelText: 'Edad',
+                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
+                  validator: _req,
                 ),
-              ),
-              const SizedBox(height: 20),
-              TextField(
-                decoration: InputDecoration(
-                  labelText: 'Género',
-                  border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                const SizedBox(height: 20),
+                TextFormField(
+                  controller: _generoCtrl,
+                  decoration: InputDecoration(
+                    labelText: 'Género',
+                    border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+                  ),
                 ),
-              ),
-              const SizedBox(height: 50),
-
-              // Botão Guardar
-              ElevatedButton(
-                onPressed: () {
-                  // Lógica para salvar os dados e navegar para a tela principal do app
-                  // Ex: Navigator.of(context).pushAndRemoveUntil(MaterialPageRoute(builder: (context) => HomeScreen()), (route) => false);
-                },
-                style: ElevatedButton.styleFrom(
-                  backgroundColor: const Color(0xFFFA7A7A),
-                  minimumSize: const Size(double.infinity, 55),
-                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+                const SizedBox(height: 50),
+                ElevatedButton(
+                  onPressed: _guardar,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFA7A7A),
+                    minimumSize: const Size(double.infinity, 55),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+                  ),
+                  child: Text(
+                    'Guardar',
+                    style: GoogleFonts.poppins(fontSize: 18, color: Colors.white, fontWeight: FontWeight.w600),
+                  ),
                 ),
-                child: Text('Guardar', style: GoogleFonts.poppins(fontSize: 18, color: Colors.white, fontWeight: FontWeight.w600)),
-              ),
-            ],
+              ],
+            ),
           ),
         ),
       ),

--- a/contador_pasos/lib/history_screen.dart
+++ b/contador_pasos/lib/history_screen.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class HistoryScreen extends StatelessWidget {
+  const HistoryScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    // Datos mock para la lista de días
+    final data = const [
+      {'dia': 'Lunes', 'pasos': 5000},
+      {'dia': 'Martes', 'pasos': 4100},
+      {'dia': 'Miércoles', 'pasos': 5000},
+      {'dia': 'Jueves', 'pasos': 4200},
+      {'dia': 'Viernes', 'pasos': 4000},
+      {'dia': 'Sábado', 'pasos': 3300},
+      {'dia': 'Domingo', 'pasos': 1200},
+    ];
+
+    const meta = 4800; // ejemplo
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+        title: Text('Historial', style: GoogleFonts.poppins(color: Colors.black, fontWeight: FontWeight.w700)),
+        centerTitle: true,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text('Pasos por día', style: GoogleFonts.poppins(fontSize: 14, color: Colors.grey[600])),
+            const SizedBox(height: 16),
+            Expanded(
+              child: ListView.separated(
+                itemCount: data.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 10),
+                itemBuilder: (context, index) {
+                  final item = data[index];
+                  final pasos = item['pasos'] as int;
+                  final progreso = (pasos / meta).clamp(0.0, 1.0);
+                  return DecoratedBox(
+                    decoration: BoxDecoration(
+                      color: const Color(0xFFF8F3F8),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    child: Padding(
+                      padding: const EdgeInsets.all(12.0),
+                      child: Row(
+                        children: [
+                          Expanded(
+                            child: Column(
+                              crossAxisAlignment: CrossAxisAlignment.start,
+                              children: [
+                                Row(
+                                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(item['dia'] as String, style: GoogleFonts.poppins(fontWeight: FontWeight.w600)),
+                                    Text('$pasos', style: GoogleFonts.poppins(color: Colors.grey[700])),
+                                  ],
+                                ),
+                                const SizedBox(height: 8),
+                                ClipRRect(
+                                  borderRadius: BorderRadius.circular(8),
+                                  child: LinearProgressIndicator(
+                                    value: progreso,
+                                    minHeight: 10,
+                                    backgroundColor: Colors.white,
+                                    color: const Color(0xFFFA7A7A),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/contador_pasos/lib/main_counter_screen.dart
+++ b/contador_pasos/lib/main_counter_screen.dart
@@ -1,10 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'dart:async'; // Para simular a contagem
+import 'dart:async'; // Para simular el conteo
 
 class MainCounterScreen extends StatefulWidget {
+  const MainCounterScreen({super.key});
+
   @override
-  _MainCounterScreenState createState() => _MainCounterScreenState();
+  State<MainCounterScreen> createState() => _MainCounterScreenState();
 }
 
 class _MainCounterScreenState extends State<MainCounterScreen> {
@@ -13,27 +15,26 @@ class _MainCounterScreenState extends State<MainCounterScreen> {
   bool _isRunning = false;
   Timer? _timer;
 
-  // Função para o botão Iniciar/Parar
+  // Constante del modo demo: 1 paso = 0.04 kcal
+  static const double _kcalPerStep = 0.04;
+
+  // Botón Iniciar/Parar
   void _startStop() {
-    setState(() {
-      _isRunning = !_isRunning;
-      if (_isRunning) {
-        // Inicia um timer para simular a contagem de passos
-        _timer = Timer.periodic(Duration(seconds: 1), (timer) {
-          setState(() {
-            _stepCount++;
-            // Fórmula de exemplo: 1 passo = 0.04 calorias
-            _calories = _stepCount * 0.04;
-          });
-        });
-      } else {
-        // Para o timer se o contador for pausado
-        _timer?.cancel();
-      }
+    if (_isRunning) {
+      _timer?.cancel();
+      setState(() => _isRunning = false);
+      return;
+    }
+    setState(() => _isRunning = true);
+    _timer = Timer.periodic(const Duration(seconds: 1), (timer) {
+      setState(() {
+        _stepCount++;
+        _calories = _stepCount * _kcalPerStep;
+      });
     });
   }
 
-  // Função para o botão Reiniciar
+  // Botón Reiniciar
   void _reset() {
     _timer?.cancel();
     setState(() {
@@ -45,7 +46,7 @@ class _MainCounterScreenState extends State<MainCounterScreen> {
 
   @override
   void dispose() {
-    _timer?.cancel(); // Garante que o timer seja cancelado ao sair da tela
+    _timer?.cancel(); // Asegura cancelar el timer al salir
     super.dispose();
   }
 
@@ -54,78 +55,90 @@ class _MainCounterScreenState extends State<MainCounterScreen> {
     return Scaffold(
       backgroundColor: Colors.white,
       appBar: AppBar(
-        title: Text('Contador de Passos', style: GoogleFonts.poppins(color: Colors.black)),
+        title: Text('Contador de pasos', style: GoogleFonts.poppins(color: Colors.black)),
         backgroundColor: Colors.white,
         elevation: 0,
+        iconTheme: const IconThemeData(color: Colors.black),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: [
-            // Mostrador de Passos
-            Text(
-              'Passos',
-              style: GoogleFonts.poppins(fontSize: 24, color: Colors.grey[600]),
-            ),
-            Text(
-              '$_stepCount',
-              style: GoogleFonts.poppins(
-                fontSize: 80,
-                fontWeight: FontWeight.bold,
-                color: Colors.black,
-              ),
-            ),
-            SizedBox(height: 40),
-
-            // Mostrador de Calorias
-            Text(
-              'Calorias',
-              style: GoogleFonts.poppins(fontSize: 24, color: Colors.grey[600]),
-            ),
-            Text(
-              _calories.toStringAsFixed(2), // Mostra com 2 casas decimais
-              style: GoogleFonts.poppins(
-                fontSize: 40,
-                fontWeight: FontWeight.bold,
-                color: Color(0xFFFA7A7A),
-              ),
-            ),
-            SizedBox(height: 60),
-
-            // Botões de Controle
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-              children: [
-                // Botão Iniciar/Parar
-                ElevatedButton(
-                  onPressed: _startStop,
-                  child: Text(_isRunning ? 'Parar' : 'Iniciar', style: TextStyle(fontSize: 18)),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: _isRunning ? Colors.grey : Color(0xFFFA7A7A),
-                    foregroundColor: Colors.white,
-                    padding: EdgeInsets.symmetric(horizontal: 40, vertical: 15),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(30),
-                    ),
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              // Banner de modo demo
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Container(
+                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+                  decoration: BoxDecoration(
+                    color: const Color(0xFFFFEFEF),
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                  child: Row(
+                    mainAxisSize: MainAxisSize.min,
+                    children: const [
+                      Icon(Icons.info_outline, size: 18, color: Color(0xFFFA7A7A)),
+                      SizedBox(width: 8),
+                      Text('Modo demo (sin sensor)', style: TextStyle(color: Color(0xFFFA7A7A))),
+                    ],
                   ),
                 ),
+              ),
 
-                // Botão Reiniciar
-                ElevatedButton(
-                  onPressed: _reset,
-                  child: Text('Reiniciar', style: TextStyle(fontSize: 18)),
-                  style: ElevatedButton.styleFrom(
-                    backgroundColor: Colors.black87,
-                    foregroundColor: Colors.white,
-                    padding: EdgeInsets.symmetric(horizontal: 40, vertical: 15),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(30),
+              // Mostrador de Pasos
+              Text('Pasos', style: GoogleFonts.poppins(fontSize: 24, color: Colors.grey[600])),
+              Text(
+                '$_stepCount',
+                style: GoogleFonts.poppins(fontSize: 80, fontWeight: FontWeight.bold, color: Colors.black),
+              ),
+              const SizedBox(height: 40),
+
+              // Mostrador de Calorías
+              Text('Calorías', style: GoogleFonts.poppins(fontSize: 24, color: Colors.grey[600])),
+              Text(
+                _calories.toStringAsFixed(2), // 2 decimales
+                style: GoogleFonts.poppins(fontSize: 40, fontWeight: FontWeight.bold, color: Color(0xFFFA7A7A)),
+              ),
+              const SizedBox(height: 6),
+              Text(
+                '$_kcalPerStep kcal por paso (modo demo)',
+                style: GoogleFonts.poppins(fontSize: 12, color: Colors.grey[600]),
+              ),
+
+              const SizedBox(height: 60),
+
+              // Botones de Control
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                children: [
+                  // Botón Iniciar/Parar
+                  ElevatedButton(
+                    onPressed: _startStop,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: _isRunning ? Colors.grey : const Color(0xFFFA7A7A),
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 15),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
                     ),
+                    child: Text(_isRunning ? 'Parar' : 'Iniciar', style: const TextStyle(fontSize: 18)),
                   ),
-                ),
-              ],
-            )
-          ],
+
+                  // Botón Reiniciar
+                  ElevatedButton(
+                    onPressed: _reset,
+                    style: ElevatedButton.styleFrom(
+                      backgroundColor: Colors.black87,
+                      foregroundColor: Colors.white,
+                      padding: const EdgeInsets.symmetric(horizontal: 40, vertical: 15),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+                    ),
+                    child: const Text('Reiniciar', style: TextStyle(fontSize: 18)),
+                  ),
+                ],
+              ),
+            ],
+          ),
         ),
       ),
     );

--- a/contador_pasos/lib/models/user_info.dart
+++ b/contador_pasos/lib/models/user_info.dart
@@ -1,0 +1,13 @@
+class UserInfo {
+  final double pesoKg;
+  final double alturaCm;
+  final int edad;
+  final String genero;
+
+  const UserInfo({
+    required this.pesoKg,
+    required this.alturaCm,
+    required this.edad,
+    required this.genero,
+  });
+}

--- a/contador_pasos/lib/summary_screen.dart
+++ b/contador_pasos/lib/summary_screen.dart
@@ -1,0 +1,260 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'models/user_info.dart';
+import 'history_screen.dart';
+
+class SummaryScreen extends StatelessWidget {
+  final UserInfo userInfo;
+  const SummaryScreen({super.key, required this.userInfo});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    // Mock inicial (luego conectamos fuentes reales)
+    final pasos = 0; // integrar pedómetro/contador
+    final calorias = pasos * 0.04; // consistente con MainCounterScreen
+    final ritmo = 74; // mock
+
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        leading: IconButton(
+          icon: const Icon(Icons.arrow_back_ios, color: Colors.black),
+          onPressed: () => Navigator.of(context).pop(),
+        ),
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24.0),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              const SizedBox(height: 8),
+              Text('Información de hoy', style: GoogleFonts.poppins(fontSize: 28, fontWeight: FontWeight.w800)),
+              const SizedBox(height: 6),
+              Text(
+                _mesAnoActual(),
+                style: GoogleFonts.poppins(fontSize: 14, color: Colors.grey[600]),
+              ),
+              const SizedBox(height: 24),
+
+              // Cards superiores (Calorías / Pasos)
+              Row(
+                children: [
+                  Expanded(
+                    child: _InfoCard(
+                      icon: Icons.local_fire_department,
+                      title: 'Calorías',
+                      value: calorias.toStringAsFixed(2),
+                      unit: 'Kcal',
+                    ),
+                  ),
+                  const SizedBox(width: 14),
+                  Expanded(
+                    child: _InfoCard(
+                      icon: Icons.directions_walk,
+                      title: 'Pasos',
+                      value: '$pasos',
+                      unit: 'pasos',
+                    ),
+                  ),
+                ],
+              ),
+
+              const SizedBox(height: 14),
+
+              // Card de Ritmo Cardíaco (ancho completo)
+              _BigInfoCard(
+                icon: Icons.favorite_border,
+                title: 'Ritmo Cardíaco',
+                value: '$ritmo',
+                unit: 'bpm',
+              ),
+
+              // Placeholder del gráfico inferior (para mantener layout del Figma)
+              const SizedBox(height: 18),
+              _GraphPlaceholder(),
+
+              const Spacer(),
+
+              // Botón Historial
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: () {
+                    Navigator.of(context).push(
+                      MaterialPageRoute(
+                        builder: (_) => const HistoryScreen(),
+                      ),
+                    );
+                  },
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFFFA7A7A),
+                    minimumSize: const Size(double.infinity, 55),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(30)),
+                    elevation: 0,
+                  ),
+                  child: Text(
+                    'Historial',
+                    style: GoogleFonts.poppins(fontSize: 18, color: Colors.white, fontWeight: FontWeight.w600),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+
+  String _mesAnoActual() {
+    const meses = [
+      'Enero','Febrero','Marzo','Abril','Mayo','Junio',
+      'Julio','Agosto','Septiembre','Octubre','Noviembre','Diciembre'
+    ];
+    final now = DateTime.now();
+    return '${meses[now.month - 1]}, ${now.year}';
+  }
+}
+
+class _InfoCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String value;
+  final String unit;
+  const _InfoCard({
+    required this.icon,
+    required this.title,
+    required this.value,
+    required this.unit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8F3F8), // leve rosado/gris como en el Figma
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(title, style: GoogleFonts.poppins(fontSize: 14, color: Colors.grey[700])),
+                Icon(icon, color: const Color(0xFFFA7A7A)),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(value, style: GoogleFonts.poppins(fontSize: 26, fontWeight: FontWeight.w700)),
+                const SizedBox(width: 6),
+                Text(unit, style: GoogleFonts.poppins(fontSize: 12, color: Colors.grey[600])),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _BigInfoCard extends StatelessWidget {
+  final IconData icon;
+  final String title;
+  final String value;
+  final String unit;
+  const _BigInfoCard({
+    required this.icon,
+    required this.title,
+    required this.value,
+    required this.unit,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        color: const Color(0xFFF8F3F8),
+        borderRadius: BorderRadius.circular(16),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 4),
+          ),
+        ],
+      ),
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Text(title, style: GoogleFonts.poppins(fontSize: 14, color: Colors.grey[700])),
+                Icon(icon, color: const Color(0xFFFA7A7A)),
+              ],
+            ),
+            const SizedBox(height: 12),
+            Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                Text(value, style: GoogleFonts.poppins(fontSize: 26, fontWeight: FontWeight.w700)),
+                const SizedBox(width: 6),
+                Text(unit, style: GoogleFonts.poppins(fontSize: 12, color: Colors.grey[600])),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _GraphPlaceholder extends StatelessWidget {
+  const _GraphPlaceholder();
+  @override
+  Widget build(BuildContext context) {
+    return SizedBox(
+      height: 80,
+      child: Row(
+        children: List.generate(
+          16,
+          (i) => Expanded(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 2.0),
+              child: Align(
+                alignment: Alignment.bottomCenter,
+                child: Container(
+                  height: (20 + (i * 5) % 60).toDouble(),
+                  decoration: BoxDecoration(
+                    color: i % 4 == 0 ? Colors.black : const Color(0xFFFA7A7A).withOpacity(0.4),
+                    borderRadius: BorderRadius.circular(4),
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
**Resumen**
- Nueva pantalla **Información de hoy** (UI fiel al Figma: calorías, pasos, ritmo + gráfico).
- Nueva pantalla **Historial** (lista semanal con barras de progreso).
- `AddInfoScreen` ahora guarda datos y navega a **Información de hoy** (usa `UserInfo`).
- `MainCounterScreen`: banner **“Modo demo (sin sensor)”** y textos en español.
- Android: se fija `ndkVersion = "27.0.12077973"` para alinear con `path_provider_android`.

**Archivos nuevos**
- `lib/models/user_info.dart`
- `lib/summary_screen.dart`
- `lib/history_screen.dart`

**Archivos modificados**
- `lib/add_info_screen.dart` (Stateful + validación + navegación)
- `lib/main_counter_screen.dart` (banner demo + copy ES)
- `android/app/build.gradle.kts` (NDK 27)

**Cómo probar**
1. Splash → Acceso → **Crear Cuenta**.
2. **Agregar información** → **Guardar** → **Información de hoy**.
3. Tap **Historial** → lista con barras.
4. Acceso → login mock (`teste@email.com` / `123`) → **Contador de pasos**:
   - Iniciar/Parar incrementa pasos (0.04 kcal por paso).
   - Reiniciar vuelve a 0.

**Notas**
- Conteo y calorías en **modo demo** (no usa sensor).
- Se excluyen archivos generados de desktop (linux/macos/windows).

![info-hoy](https://github.com/user-attachments/assets/b3e4acee-4143-449f-87f7-86c79fda9ba6)
![historial](https://github.com/user-attachments/assets/9d70fc76-8af9-42b3-8822-a6d0d933c02d)

